### PR TITLE
Prevent overlong tag strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
-basic_geometries.osm
 test/*.err
 test/id_outfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+basic_geometries.osm
+test/*.err
+test/id_outfile
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+#PyCharm
+.idea/
+
 # Rope project settings
 .ropeproject
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,5 @@
 ## Tests
-Test your code and make sure it passes. cram is used for tests:
-
- 1. Make sure you have `libxml2-utils`, `osmctools` and  `protobuf-compiler` installed on your system and the [optional-requirements.txt](optional-requirements.txt) installd in your python env.
- 2. Install `cram`: `pip install cram`
- 3. Run `cram`: `cram test/`
+Test your code and make sure it passes. cram is used for tests. See [test.yml](.github/workflows/test.yml) for instructions on how to install and run them.
 
 Changes in speed-critical parts of the code may require profiling.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 ## Tests
-Test your code and make sure it passes. cram is used for tests.
+Test your code and make sure it passes. cram is used for tests:
+
+ 1. Make sure you have `libxml2-utils`, `osmctools` and  `protobuf-compiler` installed on your system and the [optional-requirements.txt](optional-requirements.txt) installd in your python env.
+ 2. Install `cram`: `pip install cram`
+ 3. Run `cram`: `cram test/`
 
 Changes in speed-critical parts of the code may require profiling.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ usage: ogr2osm [-h] [--version] [-t TRANSLATION] [--encoding ENCODING]
                [--split-ways MAXNODESPERWAY] [--id ID] [--idfile IDFILE]
                [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                [--never-download] [--never-upload] [--locked] [--add-bounds]
-               [--suppress-empty-tags] [--max-tag-value-length MAXTAGVALUELENGTH]
+               [--suppress-empty-tags] [--max-tag-length MAXTAGLENGTH]
                DATASOURCE
 
 positional arguments:
@@ -127,10 +127,10 @@ options:
   --add-bounds          Add boundaries to output file
   --suppress-empty-tags
                         Suppress empty tags
-  --max-tag-value-length MAXTAGVALUELENGTH
-                        Set max character length of tag values. Exceeding values
-                        will be truncated and end with '...'. Defaults to the OSM API
-                        limit of 255. Values smaller 3 disable the limit.
+  --max-tag-length MAXTAGLENGTH
+                        Set max character length of tag values. Exceeding
+                        values will be truncated and end with '...'. Defaults
+                        to 255. Values smaller than 3 disable the limit.
 ```
 
 ### As a library
@@ -201,7 +201,7 @@ datawriter = ogr2osm.OsmDataWriter(output_file)
 # - locked: --locked parameter
 # - significant_digits: --significant-digits parameter
 # - suppress_empty_tags: --suppress-empty-tags parameter
-# - max_tag_length: --max-tag-value-length parameter
+# - max_tag_length: --max-tag-length parameter
 osmdata.output(datawriter)
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ usage: ogr2osm [-h] [--version] [-t TRANSLATION] [--encoding ENCODING]
                [--split-ways MAXNODESPERWAY] [--id ID] [--idfile IDFILE]
                [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                [--never-download] [--never-upload] [--locked] [--add-bounds]
-               [--suppress-empty-tags]
+               [--suppress-empty-tags] [--max-tag-value-length MAXTAGVALUELENGTH]
                DATASOURCE
 
 positional arguments:
@@ -127,6 +127,10 @@ options:
   --add-bounds          Add boundaries to output file
   --suppress-empty-tags
                         Suppress empty tags
+  --max-tag-value-length MAXTAGVALUELENGTH
+                        Set max character length of tag values. Exceeding values
+                        will be truncated and end with '...'. Defaults to the OSM API
+                        limit of 255. Values smaller 3 disable the limit.
 ```
 
 ### As a library
@@ -197,6 +201,7 @@ datawriter = ogr2osm.OsmDataWriter(output_file)
 # - locked: --locked parameter
 # - significant_digits: --significant-digits parameter
 # - suppress_empty_tags: --suppress-empty-tags parameter
+# - max_tag_length: --max-tag-value-length parameter
 osmdata.output(datawriter)
 ```
 

--- a/ogr2osm/datawriter_base_class.py
+++ b/ogr2osm/datawriter_base_class.py
@@ -27,6 +27,9 @@ class DataWriterBase:
         dw.close()
     '''
 
+    MAX_TAG_LENGTH = 255
+    PLACEHOLDER = ' ... '
+
     def __init__(self):
         pass
 

--- a/ogr2osm/datawriter_base_class.py
+++ b/ogr2osm/datawriter_base_class.py
@@ -28,7 +28,7 @@ class DataWriterBase:
     '''
 
     MAX_TAG_LENGTH = 255
-    PLACEHOLDER = ' ... '
+    PLACEHOLDER = '...'
 
     def __init__(self):
         pass

--- a/ogr2osm/datawriter_base_class.py
+++ b/ogr2osm/datawriter_base_class.py
@@ -27,7 +27,7 @@ class DataWriterBase:
         dw.close()
     '''
 
-    PLACEHOLDER = '...'
+    TAG_OVERFLOW = '...'
 
     def __init__(self):
         pass

--- a/ogr2osm/datawriter_base_class.py
+++ b/ogr2osm/datawriter_base_class.py
@@ -27,7 +27,6 @@ class DataWriterBase:
         dw.close()
     '''
 
-    MAX_TAG_LENGTH = 255
     PLACEHOLDER = '...'
 
     def __init__(self):

--- a/ogr2osm/ogr2osm.py
+++ b/ogr2osm/ogr2osm.py
@@ -131,8 +131,9 @@ def parse_commandline(logger):
     parser.add_argument("--suppress-empty-tags", dest="suppressEmptyTags", action="store_true",
                         help="Suppress empty tags")
     parser.add_argument("--max-tag-value-length", dest="maxTagValueLength", type=int, default=255,
-                        help="Set max length of tag values. Defaults to %(default)s, " +
-                             "0 disables the limit")
+                        help="Set max character length of tag values. Exceeding values will be truncated and end with "
+                             f"'{OsmDataWriter.PLACEHOLDER}'. Defaults to the OSM API limit of %(default)s. Values "
+                             f"smaller {len(OsmDataWriter.PLACEHOLDER)} disable the limit.")
     parser.add_argument("--add-version", dest="addVersion", action="store_true",
                         help=argparse.SUPPRESS) # can cause problems when used inappropriately
     parser.add_argument("--add-timestamp", dest="addTimestamp", action="store_true",
@@ -191,6 +192,9 @@ def parse_commandline(logger):
 
     if not params.forceOverwrite and os.path.exists(params.outputFile):
         parser.error("ERROR: output file '%s' exists" % params.outputFile)
+
+    if params.maxTagValueLength < len(OsmDataWriter.PLACEHOLDER):
+        params.maxTagValueLength = sys.maxsize
 
     return params
 

--- a/ogr2osm/ogr2osm.py
+++ b/ogr2osm/ogr2osm.py
@@ -130,10 +130,11 @@ def parse_commandline(logger):
                         help="Add boundaries to output file")
     parser.add_argument("--suppress-empty-tags", dest="suppressEmptyTags", action="store_true",
                         help="Suppress empty tags")
-    parser.add_argument("--max-tag-value-length", dest="maxTagValueLength", type=int, default=255,
-                        help="Set max character length of tag values. Exceeding values will be truncated and end with "
-                             f"'{OsmDataWriter.PLACEHOLDER}'. Defaults to the OSM API limit of %(default)s. Values "
-                             f"smaller {len(OsmDataWriter.PLACEHOLDER)} disable the limit.")
+    parser.add_argument("--max-tag-length", dest="maxTagLength", type=int, default=255,
+                        help="Set max character length of tag values. Exceeding values will be " +
+                             f"truncated and end with '{OsmDataWriter.TAG_OVERFLOW}'. Defaults " +
+                             "to %(default)s. Values smaller than " +
+                             f"{len(OsmDataWriter.TAG_OVERFLOW)} disable the limit.")
     parser.add_argument("--add-version", dest="addVersion", action="store_true",
                         help=argparse.SUPPRESS) # can cause problems when used inappropriately
     parser.add_argument("--add-timestamp", dest="addTimestamp", action="store_true",
@@ -193,7 +194,7 @@ def parse_commandline(logger):
     if not params.forceOverwrite and os.path.exists(params.outputFile):
         parser.error("ERROR: output file '%s' exists" % params.outputFile)
 
-    if params.maxTagValueLength < len(OsmDataWriter.PLACEHOLDER):
+    if params.maxTagLength < len(OsmDataWriter.TAG_OVERFLOW):
         params.maxTagValueLength = sys.maxsize
 
     return params
@@ -280,12 +281,12 @@ def main():
     datawriter = None
     if params.pbf:
         datawriter = PbfDataWriter(params.outputFile, params.addVersion, params.addTimestamp, \
-                                   params.suppressEmptyTags, params.maxTagValueLength)
+                                   params.suppressEmptyTags, params.maxTagLength)
     else:
         datawriter = OsmDataWriter(params.outputFile, params.neverUpload, params.noUploadFalse, \
                                    params.neverDownload, params.locked, params.addVersion, \
                                    params.addTimestamp, params.significantDigits, \
-                                   params.suppressEmptyTags, params.maxTagValueLength)
+                                   params.suppressEmptyTags, params.maxTagLength)
     osmdata.output(datawriter)
 
     osmdata.save_current_id_to_file(params.saveid)

--- a/ogr2osm/ogr2osm.py
+++ b/ogr2osm/ogr2osm.py
@@ -130,6 +130,9 @@ def parse_commandline(logger):
                         help="Add boundaries to output file")
     parser.add_argument("--suppress-empty-tags", dest="suppressEmptyTags", action="store_true",
                         help="Suppress empty tags")
+    parser.add_argument("--max-tag-value-length", dest="maxTagValueLength", type=int, default=255,
+                        help="Set max length of tag values. Defaults to %(default)s, " +
+                             "0 disables the limit")
     parser.add_argument("--add-version", dest="addVersion", action="store_true",
                         help=argparse.SUPPRESS) # can cause problems when used inappropriately
     parser.add_argument("--add-timestamp", dest="addTimestamp", action="store_true",
@@ -273,12 +276,12 @@ def main():
     datawriter = None
     if params.pbf:
         datawriter = PbfDataWriter(params.outputFile, params.addVersion, params.addTimestamp, \
-                                   params.suppressEmptyTags)
+                                   params.suppressEmptyTags, params.maxTagValueLength)
     else:
         datawriter = OsmDataWriter(params.outputFile, params.neverUpload, params.noUploadFalse, \
                                    params.neverDownload, params.locked, params.addVersion, \
                                    params.addTimestamp, params.significantDigits, \
-                                   params.suppressEmptyTags)
+                                   params.suppressEmptyTags, params.maxTagValueLength)
     osmdata.output(datawriter)
 
     osmdata.save_current_id_to_file(params.saveid)

--- a/ogr2osm/osm_datawriter.py
+++ b/ogr2osm/osm_datawriter.py
@@ -74,7 +74,8 @@ class OsmDataWriter(DataWriterBase):
             self.f.write(osm_geom.to_xml(self.attributes, \
                                          self.significant_digits, \
                                          self.suppress_empty_tags, \
-                                         self.max_tag_length))
+                                         self.max_tag_length, \
+                                         DataWriterBase.TAG_OVERFLOW))
             self.f.write('\n')
 
 

--- a/ogr2osm/osm_datawriter.py
+++ b/ogr2osm/osm_datawriter.py
@@ -18,7 +18,7 @@ from .datawriter_base_class import DataWriterBase
 class OsmDataWriter(DataWriterBase):
     def __init__(self, filename, never_upload=False, no_upload_false=False, never_download=False, \
                  locked=False, add_version=False, add_timestamp=False, significant_digits=9, \
-                 suppress_empty_tags=False):
+                 suppress_empty_tags=False, max_tag_length=255):
         self.logger = logging.getLogger(__program__)
 
         self.filename = filename
@@ -28,6 +28,7 @@ class OsmDataWriter(DataWriterBase):
         self.locked = locked
         self.significant_digits = significant_digits
         self.suppress_empty_tags = suppress_empty_tags
+        self.max_tag_length = max_tag_length
         #self.gzip_compression_level = gzip_compression_level
         self.f = None
 
@@ -72,7 +73,8 @@ class OsmDataWriter(DataWriterBase):
         for osm_geom in geoms:
             self.f.write(osm_geom.to_xml(self.attributes, \
                                          self.significant_digits, \
-                                         self.suppress_empty_tags))
+                                         self.suppress_empty_tags, \
+                                         self.max_tag_length))
             self.f.write('\n')
 
 

--- a/ogr2osm/osm_geometries.py
+++ b/ogr2osm/osm_geometries.py
@@ -12,6 +12,7 @@ accompany any distribution of this code.
 import logging
 from lxml import etree
 
+from . import DataWriterBase
 from .version import __program__
 
 class OsmId:
@@ -105,6 +106,9 @@ class OsmGeometry:
     def _add_tags_to_xml(self, xmlobject, suppress_empty_tags):
         for (key, value_list) in self.tags.items():
             value = ','.join([ v for v in value_list if v ])
+            if len(value) > DataWriterBase.MAX_TAG_LENGTH:
+                value = value[:(DataWriterBase.MAX_TAG_LENGTH - len(DataWriterBase.PLACEHOLDER))] \
+                        + DataWriterBase.PLACEHOLDER
             if value or not suppress_empty_tags:
                 tag = etree.Element('tag', { 'k':key, 'v':value })
                 xmlobject.append(tag)

--- a/ogr2osm/osm_geometries.py
+++ b/ogr2osm/osm_geometries.py
@@ -12,7 +12,6 @@ accompany any distribution of this code.
 import logging
 from lxml import etree
 
-from . import DataWriterBase
 from .version import __program__
 
 class OsmId:
@@ -103,18 +102,18 @@ class OsmGeometry:
         return self.__parents
 
 
-    def _add_tags_to_xml(self, xmlobject, suppress_empty_tags, max_tag_length):
+    def _add_tags_to_xml(self, xmlobject, suppress_empty_tags, max_tag_length, tag_overflow):
         for (key, value_list) in self.tags.items():
             value = ';'.join([ v for v in value_list if v ])
             if len(value) > max_tag_length:
-                value = value[:(max_tag_length - len(DataWriterBase.PLACEHOLDER))] \
-                        + DataWriterBase.PLACEHOLDER
+                value = value[:(max_tag_length - len(tag_overflow))] + tag_overflow
             if value or not suppress_empty_tags:
                 tag = etree.Element('tag', { 'k':key, 'v':value })
                 xmlobject.append(tag)
 
 
-    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
+    def to_xml(self, attributes, significant_digits, \
+                     suppress_empty_tags, max_tag_length, tag_overflow):
         pass
 
 
@@ -127,7 +126,8 @@ class OsmNode(OsmGeometry):
         self.tags.update({ k: (v if type(v) == list else [ v ]) for (k, v) in tags.items() })
 
 
-    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
+    def to_xml(self, attributes, significant_digits, \
+                     suppress_empty_tags, max_tag_length, tag_overflow):
         xmlattrs = { 'visible':'true', \
                      'id':('%d' % self.id), \
                      'lat':(('%%.%df' % significant_digits) % self.y).strip('0'), \
@@ -136,7 +136,7 @@ class OsmNode(OsmGeometry):
 
         xmlobject = etree.Element('node', xmlattrs)
 
-        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length)
+        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length, tag_overflow)
 
         return etree.tostring(xmlobject, encoding='unicode')
 
@@ -149,7 +149,8 @@ class OsmWay(OsmGeometry):
         self.tags.update({ k: (v if type(v) == list else [ v ]) for (k, v) in tags.items() })
 
 
-    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
+    def to_xml(self, attributes, significant_digits, \
+                     suppress_empty_tags, max_tag_length, tag_overflow):
         xmlattrs = { 'visible':'true', 'id':('%d' % self.id) }
         xmlattrs.update(attributes)
 
@@ -159,7 +160,7 @@ class OsmWay(OsmGeometry):
             nd = etree.Element('nd', { 'ref':('%d' % node.id) })
             xmlobject.append(nd)
 
-        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length)
+        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length, tag_overflow)
 
         return etree.tostring(xmlobject, encoding='unicode')
 
@@ -179,7 +180,8 @@ class OsmRelation(OsmGeometry):
         return member_role
 
 
-    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
+    def to_xml(self, attributes, significant_digits, \
+                     suppress_empty_tags, max_tag_length, tag_overflow):
         xmlattrs = { 'visible':'true', 'id':('%d' % self.id) }
         xmlattrs.update(attributes)
 
@@ -197,6 +199,6 @@ class OsmRelation(OsmGeometry):
                                                   'ref':('%d' % member.id), 'role':role })
             xmlobject.append(xmlmember)
 
-        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length)
+        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length, tag_overflow)
 
         return etree.tostring(xmlobject, encoding='unicode')

--- a/ogr2osm/osm_geometries.py
+++ b/ogr2osm/osm_geometries.py
@@ -103,18 +103,18 @@ class OsmGeometry:
         return self.__parents
 
 
-    def _add_tags_to_xml(self, xmlobject, suppress_empty_tags):
+    def _add_tags_to_xml(self, xmlobject, suppress_empty_tags, max_tag_length):
         for (key, value_list) in self.tags.items():
             value = ';'.join([ v for v in value_list if v ])
-            if len(value) > DataWriterBase.MAX_TAG_LENGTH:
-                value = value[:(DataWriterBase.MAX_TAG_LENGTH - len(DataWriterBase.PLACEHOLDER))] \
+            if len(value) > max_tag_length:
+                value = value[:(max_tag_length - len(DataWriterBase.PLACEHOLDER))] \
                         + DataWriterBase.PLACEHOLDER
             if value or not suppress_empty_tags:
                 tag = etree.Element('tag', { 'k':key, 'v':value })
                 xmlobject.append(tag)
 
 
-    def to_xml(self, attributes, significant_digits):
+    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
         pass
 
 
@@ -127,7 +127,7 @@ class OsmNode(OsmGeometry):
         self.tags.update({ k: (v if type(v) == list else [ v ]) for (k, v) in tags.items() })
 
 
-    def to_xml(self, attributes, significant_digits, suppress_empty_tags):
+    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
         xmlattrs = { 'visible':'true', \
                      'id':('%d' % self.id), \
                      'lat':(('%%.%df' % significant_digits) % self.y).strip('0'), \
@@ -136,7 +136,7 @@ class OsmNode(OsmGeometry):
 
         xmlobject = etree.Element('node', xmlattrs)
 
-        self._add_tags_to_xml(xmlobject, suppress_empty_tags)
+        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length)
 
         return etree.tostring(xmlobject, encoding='unicode')
 
@@ -149,7 +149,7 @@ class OsmWay(OsmGeometry):
         self.tags.update({ k: (v if type(v) == list else [ v ]) for (k, v) in tags.items() })
 
 
-    def to_xml(self, attributes, significant_digits, suppress_empty_tags):
+    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
         xmlattrs = { 'visible':'true', 'id':('%d' % self.id) }
         xmlattrs.update(attributes)
 
@@ -159,7 +159,7 @@ class OsmWay(OsmGeometry):
             nd = etree.Element('nd', { 'ref':('%d' % node.id) })
             xmlobject.append(nd)
 
-        self._add_tags_to_xml(xmlobject, suppress_empty_tags)
+        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length)
 
         return etree.tostring(xmlobject, encoding='unicode')
 
@@ -179,7 +179,7 @@ class OsmRelation(OsmGeometry):
         return member_role
 
 
-    def to_xml(self, attributes, significant_digits, suppress_empty_tags):
+    def to_xml(self, attributes, significant_digits, suppress_empty_tags, max_tag_length):
         xmlattrs = { 'visible':'true', 'id':('%d' % self.id) }
         xmlattrs.update(attributes)
 
@@ -197,6 +197,6 @@ class OsmRelation(OsmGeometry):
                                                   'ref':('%d' % member.id), 'role':role })
             xmlobject.append(xmlmember)
 
-        self._add_tags_to_xml(xmlobject, suppress_empty_tags)
+        self._add_tags_to_xml(xmlobject, suppress_empty_tags, max_tag_length)
 
         return etree.tostring(xmlobject, encoding='unicode')

--- a/ogr2osm/pbf_datawriter.py
+++ b/ogr2osm/pbf_datawriter.py
@@ -34,7 +34,7 @@ try:
     # https://wiki.openstreetmap.org/wiki/PBF_Format
 
     class PbfPrimitiveGroup:
-        def __init__(self, add_version, add_timestamp, suppress_empty_tags):
+        def __init__(self, add_version, add_timestamp, suppress_empty_tags, max_tag_length):
             self.stringtable = {}
             self._add_string("")
 
@@ -47,6 +47,7 @@ try:
             if self._add_timestamp:
                 self._timestamp = time.time()
             self.suppress_empty_tags = suppress_empty_tags
+            self.max_tag_length = max_tag_length
 
             self.granularity = 100
             self.lat_offset = 0
@@ -75,8 +76,8 @@ try:
             '''
             for (key, value_list) in tags.items():
                 value = ';'.join([ v for v in value_list if v ])
-                if len(value) > DataWriterBase.MAX_TAG_LENGTH:
-                    value = value[:(DataWriterBase.MAX_TAG_LENGTH - len(DataWriterBase.PLACEHOLDER))] \
+                if len(value) > self.max_tag_length:
+                    value = value[:(self.max_tag_length - len(DataWriterBase.PLACEHOLDER))] \
                             + DataWriterBase.PLACEHOLDER
                 if value or not self.suppress_empty_tags:
                     yield (self._add_string(key), self._add_string(value))
@@ -105,8 +106,8 @@ try:
 
 
     class PbfPrimitiveGroupDenseNodes(PbfPrimitiveGroup):
-        def __init__(self, add_version, add_timestamp, suppress_empty_tags):
-            super().__init__(add_version, add_timestamp, suppress_empty_tags)
+        def __init__(self, add_version, add_timestamp, suppress_empty_tags, max_tag_length):
+            super().__init__(add_version, add_timestamp, suppress_empty_tags, max_tag_length)
 
             self.__last_id = 0
             self.__last_timestamp = 0
@@ -150,8 +151,8 @@ try:
 
 
     class PbfPrimitiveGroupWays(PbfPrimitiveGroup):
-        def __init__(self, add_version, add_timestamp, suppress_empty_tags):
-            super().__init__(add_version, add_timestamp, suppress_empty_tags)
+        def __init__(self, add_version, add_timestamp, suppress_empty_tags, max_tag_length):
+            super().__init__(add_version, add_timestamp, suppress_empty_tags, max_tag_length)
 
 
         def add_way(self, osmway):
@@ -180,8 +181,8 @@ try:
 
 
     class PbfPrimitiveGroupRelations(PbfPrimitiveGroup):
-        def __init__(self, add_version, add_timestamp, suppress_empty_tags):
-            super().__init__(add_version, add_timestamp, suppress_empty_tags)
+        def __init__(self, add_version, add_timestamp, suppress_empty_tags, max_tag_length):
+            super().__init__(add_version, add_timestamp, suppress_empty_tags, max_tag_length)
 
 
         def add_relation(self, osmrelation):
@@ -220,7 +221,7 @@ try:
 
     class PbfDataWriter(DataWriterBase):
         def __init__(self, filename, add_version=False, add_timestamp=False, \
-                     suppress_empty_tags=False):
+                     suppress_empty_tags=False, max_tag_length=255):
             self.logger = logging.getLogger(__program__)
 
             self.filename = filename

--- a/ogr2osm/pbf_datawriter.py
+++ b/ogr2osm/pbf_datawriter.py
@@ -228,6 +228,7 @@ try:
             self.add_version = add_version
             self.add_timestamp = add_timestamp
             self.suppress_empty_tags = suppress_empty_tags
+            self.max_tag_length = max_tag_length
 
             self.__max_nodes_per_node_block = 8000
             self.__max_node_refs_per_way_block = 32000
@@ -294,7 +295,8 @@ try:
             for i in range(0, len(nodes), self.__max_nodes_per_node_block):
                 primitive_group = PbfPrimitiveGroupDenseNodes(self.add_version, \
                                                               self.add_timestamp, \
-                                                              self.suppress_empty_tags)
+                                                              self.suppress_empty_tags,
+                                                              self.max_tag_length)
                 for node in nodes[i:i+self.__max_nodes_per_node_block]:
                     primitive_group.add_node(node)
                 self.__write_primitive_block(primitive_group)
@@ -308,7 +310,8 @@ try:
                 if amount_node_refs == 0:
                     primitive_group = PbfPrimitiveGroupWays(self.add_version, \
                                                             self.add_timestamp, \
-                                                            self.suppress_empty_tags)
+                                                            self.suppress_empty_tags,
+                                                            self.max_tag_length)
                 primitive_group.add_way(way)
                 amount_node_refs += len(way.nodes)
                 if amount_node_refs > self.__max_node_refs_per_way_block:
@@ -327,7 +330,8 @@ try:
                 if amount_member_refs == 0:
                     primitive_group = PbfPrimitiveGroupRelations(self.add_version, \
                                                                  self.add_timestamp, \
-                                                                 self.suppress_empty_tags)
+                                                                 self.suppress_empty_tags,
+                                                                 self.max_tag_length)
                 primitive_group.add_relation(relation)
                 amount_member_refs += len(relation.members)
                 if amount_member_refs > self.__max_member_refs_per_relation_block:

--- a/ogr2osm/pbf_datawriter.py
+++ b/ogr2osm/pbf_datawriter.py
@@ -77,8 +77,8 @@ try:
             for (key, value_list) in tags.items():
                 value = ';'.join([ v for v in value_list if v ])
                 if len(value) > self.max_tag_length:
-                    value = value[:(self.max_tag_length - len(DataWriterBase.PLACEHOLDER))] \
-                            + DataWriterBase.PLACEHOLDER
+                    value = value[:(self.max_tag_length - len(DataWriterBase.TAG_OVERFLOW))] \
+                            + DataWriterBase.TAG_OVERFLOW
                 if value or not self.suppress_empty_tags:
                     yield (self._add_string(key), self._add_string(value))
 
@@ -295,7 +295,7 @@ try:
             for i in range(0, len(nodes), self.__max_nodes_per_node_block):
                 primitive_group = PbfPrimitiveGroupDenseNodes(self.add_version, \
                                                               self.add_timestamp, \
-                                                              self.suppress_empty_tags,
+                                                              self.suppress_empty_tags, \
                                                               self.max_tag_length)
                 for node in nodes[i:i+self.__max_nodes_per_node_block]:
                     primitive_group.add_node(node)
@@ -310,7 +310,7 @@ try:
                 if amount_node_refs == 0:
                     primitive_group = PbfPrimitiveGroupWays(self.add_version, \
                                                             self.add_timestamp, \
-                                                            self.suppress_empty_tags,
+                                                            self.suppress_empty_tags, \
                                                             self.max_tag_length)
                 primitive_group.add_way(way)
                 amount_node_refs += len(way.nodes)
@@ -330,7 +330,7 @@ try:
                 if amount_member_refs == 0:
                     primitive_group = PbfPrimitiveGroupRelations(self.add_version, \
                                                                  self.add_timestamp, \
-                                                                 self.suppress_empty_tags,
+                                                                 self.suppress_empty_tags, \
                                                                  self.max_tag_length)
                 primitive_group.add_relation(relation)
                 amount_member_refs += len(relation.members)

--- a/ogr2osm/pbf_datawriter.py
+++ b/ogr2osm/pbf_datawriter.py
@@ -75,6 +75,9 @@ try:
             '''
             for (key, value_list) in tags.items():
                 value = ','.join([ v for v in value_list if v ])
+                if len(value) > DataWriterBase.MAX_TAG_LENGTH:
+                    value = value[:(DataWriterBase.MAX_TAG_LENGTH - len(DataWriterBase.PLACEHOLDER))] \
+                            + DataWriterBase.PLACEHOLDER
                 if value or not self.suppress_empty_tags:
                     yield (self._add_string(key), self._add_string(value))
 

--- a/test/basic_usage.t
+++ b/test/basic_usage.t
@@ -13,6 +13,7 @@ usage:
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
                  [--suppress-empty-tags]
+                 [--max-tag-value-length MAXTAGVALUELENGTH]
                  DATASOURCE
   
   positional arguments:
@@ -69,6 +70,11 @@ usage:
     --add-bounds          Add boundaries to output file
     --suppress-empty-tags
                           Suppress empty tags
+    --max-tag-value-length MAXTAGVALUELENGTH
+                          Set max character length of tag values. Exceeding
+                          values will be truncated and end with '...'. Defaults
+                          to the OSM API limit of 255. Values smaller 3 disable
+                          the limit.
 
 						  
 require_output_file_when_using_db_source:
@@ -82,6 +88,7 @@ require_output_file_when_using_db_source:
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
                  [--suppress-empty-tags]
+                 [--max-tag-value-length MAXTAGVALUELENGTH]
                  DATASOURCE
   ogr2osm: error: ERROR: An output file must be explicitly specified when using a database source
   [2]
@@ -97,6 +104,7 @@ require_query_when_using_db_source:
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
                  [--suppress-empty-tags]
+                 [--max-tag-value-length MAXTAGVALUELENGTH]
                  DATASOURCE
   ogr2osm: error: ERROR: You must specify a query with --sql when using a database source
   [2]
@@ -139,6 +147,7 @@ duplicatefile:
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
                  [--suppress-empty-tags]
+                 [--max-tag-value-length MAXTAGVALUELENGTH]
                  DATASOURCE
   ogr2osm: error: ERROR: output file '.*basic_geometries.osm' exists (re)
   [2]

--- a/test/basic_usage.t
+++ b/test/basic_usage.t
@@ -12,8 +12,7 @@ usage:
                  [--split-ways MAXNODESPERWAY] [--id ID] [--idfile IDFILE]
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
-                 [--suppress-empty-tags]
-                 [--max-tag-value-length MAXTAGVALUELENGTH]
+                 [--suppress-empty-tags] [--max-tag-length MAXTAGLENGTH]
                  DATASOURCE
   
   positional arguments:
@@ -70,11 +69,10 @@ usage:
     --add-bounds          Add boundaries to output file
     --suppress-empty-tags
                           Suppress empty tags
-    --max-tag-value-length MAXTAGVALUELENGTH
+    --max-tag-length MAXTAGLENGTH
                           Set max character length of tag values. Exceeding
                           values will be truncated and end with '...'. Defaults
-                          to the OSM API limit of 255. Values smaller 3 disable
-                          the limit.
+                          to 255. Values smaller than 3 disable the limit.
 
 						  
 require_output_file_when_using_db_source:
@@ -87,8 +85,7 @@ require_output_file_when_using_db_source:
                  [--split-ways MAXNODESPERWAY] [--id ID] [--idfile IDFILE]
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
-                 [--suppress-empty-tags]
-                 [--max-tag-value-length MAXTAGVALUELENGTH]
+                 [--suppress-empty-tags] [--max-tag-length MAXTAGLENGTH]
                  DATASOURCE
   ogr2osm: error: ERROR: An output file must be explicitly specified when using a database source
   [2]
@@ -103,8 +100,7 @@ require_query_when_using_db_source:
                  [--split-ways MAXNODESPERWAY] [--id ID] [--idfile IDFILE]
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
-                 [--suppress-empty-tags]
-                 [--max-tag-value-length MAXTAGVALUELENGTH]
+                 [--suppress-empty-tags] [--max-tag-length MAXTAGLENGTH]
                  DATASOURCE
   ogr2osm: error: ERROR: You must specify a query with --sql when using a database source
   [2]
@@ -146,8 +142,7 @@ duplicatefile:
                  [--split-ways MAXNODESPERWAY] [--id ID] [--idfile IDFILE]
                  [--saveid SAVEID] [-o OUTPUT] [-f] [--pbf] [--no-upload-false]
                  [--never-download] [--never-upload] [--locked] [--add-bounds]
-                 [--suppress-empty-tags]
-                 [--max-tag-value-length MAXTAGVALUELENGTH]
+                 [--suppress-empty-tags] [--max-tag-length MAXTAGLENGTH]
                  DATASOURCE
   ogr2osm: error: ERROR: output file '.*basic_geometries.osm' exists (re)
   [2]

--- a/test/osm_output.t
+++ b/test/osm_output.t
@@ -217,6 +217,31 @@ mergetagsnonempty:
   Writing file footer
   $ xmllint --format mergetags.osm | diff -uNr - $TESTDIR/mergetagsnonempty.xml
 
+tagstoolong:
+  $ ogr2osm -f $TESTDIR/shapefiles/tags_too_long.geojson
+  Using default translations
+  Preparing to convert .* (re)
+  Detected projection metadata:
+  GEOGCS["SAD69",
+      DATUM["South_American_Datum_1969",
+          SPHEROID["GRS 1967 Modified",6378160,298.25,
+              AUTHORITY["EPSG","7050"]],
+          AUTHORITY["EPSG","6618"]],
+      PRIMEM["Greenwich",0,
+          AUTHORITY["EPSG","8901"]],
+      UNIT["degree",0.0174532925199433,
+          AUTHORITY["EPSG","9122"]],
+      AXIS["Latitude",NORTH],
+      AXIS["Longitude",EAST],
+      AUTHORITY["EPSG","4618"]]
+  Splitting long ways
+  Writing file header
+  Writing nodes
+  Writing ways
+  Writing relations
+  Writing file footer
+  $ xmllint --format tags_too_long.osm | diff -uNr - $TESTDIR/tags_too_long.xml
+
 id:
   $ ogr2osm -f --id 50 $TESTDIR/shapefiles/basic_geometries.kml
   Using default translations

--- a/test/pbf_output.t
+++ b/test/pbf_output.t
@@ -223,6 +223,32 @@ mergetagsnonempty:
   $ osmconvert --drop-author mergetags.osm.pbf > mergetags.osm 2> /dev/null
   $ xmllint --format mergetags.osm | diff -uNr - $TESTDIR/mergetagsnonempty.pbf.xml
 
+tagstoolong:
+  $ ogr2osm --pbf -f $TESTDIR/shapefiles/tags_too_long.geojson
+  Using default translations
+  Preparing to convert .* (re)
+  Detected projection metadata:
+  GEOGCS["SAD69",
+      DATUM["South_American_Datum_1969",
+          SPHEROID["GRS 1967 Modified",6378160,298.25,
+              AUTHORITY["EPSG","7050"]],
+          AUTHORITY["EPSG","6618"]],
+      PRIMEM["Greenwich",0,
+          AUTHORITY["EPSG","8901"]],
+      UNIT["degree",0.0174532925199433,
+          AUTHORITY["EPSG","9122"]],
+      AXIS["Latitude",NORTH],
+      AXIS["Longitude",EAST],
+      AUTHORITY["EPSG","4618"]]
+  Splitting long ways
+  Writing file header
+  Writing nodes
+  Writing ways
+  Writing relations
+  $ osmconvert --drop-author tags_too_long.osm.pbf > tags_too_long.osm 2> /dev/null
+  \[.[0-9]\] (re)
+  $ xmllint --format tags_too_long.osm | diff -uNr - $TESTDIR/tags_too_long.pbf.xml
+
 positiveid:
   $ ogr2osm --pbf -f --positive-id $TESTDIR/shapefiles/basic_geometries.kml
   Using default translations

--- a/test/shapefiles/tags_too_long.geojson
+++ b/test/shapefiles/tags_too_long.geojson
@@ -1,0 +1,10 @@
+{
+"type": "FeatureCollection",
+"name": "sp_usinas",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::4618" } },
+"features": [
+{ "type": "Feature", "properties": { "name": "a point", "description": "Description of a point that is by itself too long: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata", "longitude": -22, "latitude": 34 }, "geometry": { "type": "Point", "coordinates": [ -22, 34 ] } },
+{ "type": "Feature", "properties": { "name": "the_point", "description": "Description of the_point", "longitude": -23.094721, "latitude": 33.4838 }, "geometry": { "type": "Point", "coordinates": [ -23.094721, 33.4838 ] } },
+{ "type": "Feature", "properties": { "name": "the_point", "description": "Alternative description of the_point that makes the joint tag too long by adding a lot of symbols like so: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna al", "longitude": -23.094721, "latitude": 33.4838 }, "geometry": { "type": "Point", "coordinates": [ -23.094721, 33.4838 ] } }
+]
+}

--- a/test/tags_too_long.pbf.xml
+++ b/test/tags_too_long.pbf.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="osmconvert 0.8.10">
+  <node id="-1" lat="34.0" lon="-22.0">
+    <tag k="name" v="a point"/>
+    <tag k="description" v="Description of a point that is by itself too long: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores e..."/>
+    <tag k="longitude" v="-22"/>
+    <tag k="latitude" v="34"/>
+  </node>
+  <node id="-2" lat="33.4838" lon="-23.094721">
+    <tag k="name" v="the_point"/>
+    <tag k="description" v="Description of the_point;Alternative description of the_point that makes the joint tag too long by adding a lot of symbols like so: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magn..."/>
+    <tag k="longitude" v="-23.094721"/>
+    <tag k="latitude" v="33.4838"/>
+  </node>
+</osm>

--- a/test/tags_too_long.xml
+++ b/test/tags_too_long.xml
@@ -8,7 +8,7 @@
   </node>
   <node visible="true" id="-2" lat="33.4838" lon="-23.094721">
     <tag k="name" v="the_point"/>
-    <tag k="description" v="Description of the_point,Alternative description of the_point that makes the joint tag too long by adding a lot of symbols like so: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magn..."/>
+    <tag k="description" v="Description of the_point;Alternative description of the_point that makes the joint tag too long by adding a lot of symbols like so: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magn..."/>
     <tag k="longitude" v="-23.094721"/>
     <tag k="latitude" v="33.4838"/>
   </node>

--- a/test/tags_too_long.xml
+++ b/test/tags_too_long.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="ogr2osm 1.1.2" upload="false">
+  <node visible="true" id="-1" lat="34." lon="-22.">
+    <tag k="name" v="a point"/>
+    <tag k="description" v="Description of a point that is by itself too long: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores e..."/>
+    <tag k="longitude" v="-22"/>
+    <tag k="latitude" v="34"/>
+  </node>
+  <node visible="true" id="-2" lat="33.4838" lon="-23.094721">
+    <tag k="name" v="the_point"/>
+    <tag k="description" v="Description of the_point,Alternative description of the_point that makes the joint tag too long by adding a lot of symbols like so: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magn..."/>
+    <tag k="longitude" v="-23.094721"/>
+    <tag k="latitude" v="33.4838"/>
+  </node>
+</osm>


### PR DESCRIPTION
When merging tags of duplicate elements, the tag string may exceed the maximum allowed number of 255 characters in OSM. I guess this could also happen, if the original source has more than 255 character attributes?

This PR prevents such tags by replacing overlong tags with `...`. I'm not sure if the static vars (`PLACEHOLDER` and `MAX_TAG_LENGTH` are stored at a reasonable location. Feel free to request any changes!

This PR additionally add info on how to run tests. I have run the test and they succeed.

This PR originates from [this](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/deleted_map) tool, where I ran into the overlong string issue [here](https://github.com/osmcode/libosmium/issues/358).

PS: Very nice tool you (all) created!

