### PR TITLE
add docker support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ secrets.DOCKERHUB_USERNAME }}/ogr2osm
+        tags: |
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=ref,event=branch
+          type=ref,event=tag
+          type=ref,event=pr
+    - name: Build and push Docker image
+      id: docker_build
+      uses: docker/build-push-action@v3
+      with:
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,11 @@
-FROM amd64/ubuntu:20.04
-
-WORKDIR /app
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        libxml2-utils \
-        python-is-python3 \
-        pip && \
-    unlink /etc/localtime && \
-    ln -s /usr/share/zoneinfo/Europe/Brussels /etc/localtime
+        libxml2-utils python3-pip libprotobuf-dev protobuf-compiler \
+        gdal-bin libgdal-dev python3-gdal osmctools && \
+    rm -rf /var/lib/apt/lists/* && \
+    python3 -m pip install -U pip setuptools wheel && \
+    pip install --upgrade protobuf ogr2osm
 
-RUN apt-get install -y \
-        gdal-bin \
-        libgdal-dev \
-        python3-gdal \
-        libprotobuf-dev \
-        protobuf-compiler \
-        osmctools
-
-RUN pip install cram lxml
-RUN pip install --upgrade protobuf
-
+ENTRYPOINT ["ogr2osm"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ogr2osm
 
-![license](https://img.shields.io/github/license/roelderickx/ogr2osm) [![test](https://github.com/roelderickx/ogr2osm/actions/workflows/test.yml/badge.svg)](https://github.com/roelderickx/ogr2osm/actions/workflows/test.yml)
+![license](https://img.shields.io/github/license/roelderickx/ogr2osm) [![test](https://github.com/roelderickx/ogr2osm/actions/workflows/test.yml/badge.svg)](https://github.com/roelderickx/ogr2osm/actions/workflows/test.yml) [![docker](https://github.com/zfb132/ogr2osm/actions/workflows/deploy.yml/badge.svg)](https://github.com/zfb132/ogr2osm/actions/workflows/deploy.yml)
 
 A tool for converting ogr-readable files like shapefiles into .pbf or .osm data
 
 ## Installation
 
-Ogr2osm requires python 3, gdal with python bindings, lxml and optionally protobuf if you want to generate pbf files. Depending on the file formats you want to read you may have to compile gdal yourself but there should be no issues with shapefiles.
+Ogr2osm requires python 3, gdal with python bindings, lxml and optionally protobuf if you want to generate pbf files. Depending on the file formats you want to read you may have to compile gdal yourself but there should be no issues with shapefiles. You can also use docker to run ogr2osm.
 
 ### Via Linux package manager
 
@@ -39,6 +39,17 @@ If you do not have the required permissions to install ogr2osm, you can run the 
 git clone https://github.com/roelderickx/ogr2osm.git
 cd ogr2osm
 python -m ogr2osm
+```
+
+## Running with Docker
+If you do not want to install ogr2osm on your system, you can run it with Docker. This is especially useful if you are on Windows or Mac and do not want to install Python and GDAL yourself.
+
+The usage of ogr2osm with Docker is the same as the usage as a standalone application. You can run ogr2osm with the following command:
+```bash
+# If you have test.json in the current directory
+# you can run the following command to convert it to an OSM file
+# and save it in the current directory
+docker run -ti --rm -v $(pwd):/app whuzfb/ogr2osm /app/test.json -o /app/test.osm
 ```
 
 ## Upgrading


### PR DESCRIPTION
I installed some different GDAL versions, so using the ogr2osm in docker is a good idea for people like me.

You should finish the following work before merging this PR:
* add secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
* change docker image name (`whuzfb/ogr2osm`) in `Readme.md` to your own
* change the url of docker badge in `Readme.md`