### PR TITLE
Add option to consider elevation when merging nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ options:
                         Split ways with more than the specified number of
                         nodes. Defaults to 1800. Any value below 2 - do not
                         split.
+  --consider-elevation  If nodes have the same (X,Y) coordinates but different
+                        Z-levels (e.g, different elevation), then they will be
+                        given different node IDs (default: False)
   --id ID               ID to start counting from for the output file.
                         Defaults to 0.
   --idfile IDFILE       Read ID to start counting from from a file.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ osmdata = ogr2osm.OsmData(translation_object)
 # - max_points_in_way: --split-ways parameter
 # - add_bounds: --add-bounds parameter
 # - start_id: --id parameter
+# - consider_elevation: --consider-elevation parameter
 osmdata.process(datasource)
 
 # 7. Instantiate either ogr2osm.OsmDataWriter or ogr2osm.PbfDataWriter and

--- a/ogr2osm/ogr2osm.py
+++ b/ogr2osm/ogr2osm.py
@@ -96,6 +96,11 @@ def parse_commandline(logger):
     parser.add_argument("--split-ways", dest="maxNodesPerWay", type=int, default=1800,
                         help="Split ways with more than the specified number of nodes. " +
                              "Defaults to %(default)s. Any value below 2 - do not split.")
+    parser.add_argument("--consider-elevation", dest="considerElevation", action="store_true",
+                        help="If nodes have the same (X,Y) coordinates but different Z-levels " + 
+                             "(e.g, different elevation), " + 
+                             "then they will be given different node IDs " +
+                             "(default: %(default)s)")
     # ID generation options
     parser.add_argument("--id", dest="id", type=int, default=0,
                         help="ID to start counting from for the output file. " +
@@ -266,7 +271,7 @@ def main():
 
     osmdata = OsmData(translation_object, \
                       params.roundingDigits, params.maxNodesPerWay, params.addBounds, \
-                      params.id, params.positiveId)
+                      params.id, params.positiveId, params.considerElevation)
 
     osmdata.load_start_id_from_file(params.idfile)
 

--- a/ogr2osm/osm_data.py
+++ b/ogr2osm/osm_data.py
@@ -18,7 +18,7 @@ from .osm_geometries import OsmId, OsmBoundary, OsmNode, OsmWay, OsmRelation
 
 class OsmData:
     def __init__(self, translation, rounding_digits=7, max_points_in_way=1800, add_bounds=False, \
-                 start_id=0, is_positive=False):
+                 start_id=0, is_positive=False, consider_elevation=False):
         self.logger = logging.getLogger(__program__)
 
         # options
@@ -26,6 +26,7 @@ class OsmData:
         self.rounding_digits = rounding_digits
         self.max_points_in_way = max_points_in_way
         self.add_bounds = add_bounds
+        self.consider_elevation = consider_elevation
 
         self.__bounds = OsmBoundary()
         self.__nodes = []
@@ -86,8 +87,7 @@ class OsmData:
     def __add_node(self, x, y, tags, is_way_member, z=None):
         rx = self.__round_number(x)
         ry = self.__round_number(y)
-        # TODO also read from cmd args to decide whether need flattening
-        rz = self.__round_number(z) if z else None
+        rz = self.__round_number(z) if self.consider_elevation and z else None
 
         # TODO deprecated
         unique_node_id = None


### PR DESCRIPTION
Fixes #36 .

### Explainer

The default of "merge all nodes regardless of elevation" is preserved. This PR simply adds an option for the user to choose: whether they want to make nodes with the same (X,Y) but different Z to be considered separate nodes.

This has a basic assumption that the provided node elevation is consistent, as shown below in the examples.

---

After enabling the `--consider-elevation` option:

### Example 1

If we started with the following candidate nodes:

```
(0, 0)
(0, 0)
(0, 0)
(0, 0)
(0, 0)
```

Then we will get the resulting unique nodes:

```
(0, 0)
```

### Example 2

If we started with the following candidate nodes:
```
(0, 0, 1)
(0, 0, 2)
(0, 0, 1)
```

Then we will get the resulting unique nodes:

```
(0, 0, 1)
(0, 0, 2)
```

### Example 3


If we started with the following candidate nodes:
```
(0, 0) (i.e., elevation data is missing)
(0, 0, 1)
(0, 0, 2)
(0, 0)
(0, 0)
(0, 0, 1)
```

Then we will get the resulting unique nodes:

```
(0, 0)
(0, 0, 1)
(0, 0, 2)
```