### PR TITLE
Fix processing for unnecessary FeatureCollections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,18 @@
 ## Tests
-Test your code and make sure it passes. cram is used for tests. See [test.yml](.github/workflows/test.yml) for instructions on how to install and run them.
+Test your code and make sure it passes.
+cram is used for tests.
+To install the test suite and run the tests, we recommend using Docker via the provided [Dockerfile](test/Dockerfile).
+```shell
+# Build image
+docker build  -f test/Dockerfile --tag ogr2osm-test
+```
+```shell
+# Run tests
+docker run -it --rm -v ./:/app ogr2osm-test test/basic_usage.t \
+  test/osm_output.t \
+  test/pbf_output.t
+```
+See the GitHub actions file [test.yml](.github/workflows/test.yml) for more details.
 
 Changes in speed-critical parts of the code may require profiling.
 

--- a/ogr2osm/osm_data.py
+++ b/ogr2osm/osm_data.py
@@ -313,7 +313,7 @@ class OsmData:
                                                             not any(members)))
             else:
                 # no support for nested collections or other unsupported types
-                self.logger.warning("Unhandled geometry in collection, type %d", geometry_type)
+                self.logger.warning("Unhandled geometry in collection, type %d", collection_geom_type)
 
         if len(members) == 1 and len(members[0].nodes) <= self.max_points_in_way:
             # only 1 polygon with 1 outer ring

--- a/ogr2osm/osm_data.py
+++ b/ogr2osm/osm_data.py
@@ -304,7 +304,8 @@ class OsmData:
             if collection_geom_type in [ ogr.wkbPoint, ogr.wkbPoint25D, \
                                          ogr.wkbMultiPoint, ogr.wkbMultiPoint25D, \
                                          ogr.wkbLineString, ogr.wkbLinearRing, ogr.wkbLineString25D, \
-                                         ogr.wkbMultiLineString, ogr.wkbMultiLineString25D ]:
+                                         ogr.wkbMultiLineString, ogr.wkbMultiLineString25D ] \
+                    or ogrgeometry.GetGeometryCount() == 1:
                 osmgeometries.extend(self.__parse_geometry(collection_geom, tags))
             elif collection_geom_type in [ ogr.wkbPolygon, ogr.wkbPolygon25D, \
                                            ogr.wkbMultiPolygon, ogr.wkbMultiPolygon25D ]:
@@ -315,12 +316,8 @@ class OsmData:
                 # no support for nested collections or other unsupported types
                 self.logger.warning("Unhandled geometry in collection, type %d", collection_geom_type)
 
-        if len(members) == 1 and len(members[0].nodes) <= self.max_points_in_way:
-            # only 1 polygon with 1 outer ring
-            member[0].tags.update(tags)
-            osmgeometries.append(member[0])
-        elif len(members) > 1:
-            osmgeometries.append(\
+        if len(members) > 1:
+            osmgeometries.append( \
                 self.__verify_duplicate_relations(potential_duplicate_relations, members, tags))
 
         return osmgeometries

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -21,3 +21,4 @@ RUN apt-get install -y \
 RUN pip install cram lxml
 RUN pip install --upgrade protobuf
 
+ENTRYPOINT ["cram"]

--- a/test/osm_output.t
+++ b/test/osm_output.t
@@ -167,6 +167,31 @@ collectionduplicate:
   Writing file footer
   $ xmllint --format collection_duplicate.osm | diff -uNr - $TESTDIR/collection.xml
 
+unnecessary_collection:
+  $ ogr2osm -f $TESTDIR/shapefiles/unnecessary_collection.geojson
+  Using default translations
+  Preparing to convert .* (re)
+  Detected projection metadata:
+  GEOGCS["WGS 84",
+      DATUM["WGS_1984",
+          SPHEROID["WGS 84",6378137,298.257223563,
+              AUTHORITY["EPSG","7030"]],
+          AUTHORITY["EPSG","6326"]],
+      PRIMEM["Greenwich",0,
+          AUTHORITY["EPSG","8901"]],
+      UNIT["degree",0.0174532925199433,
+          AUTHORITY["EPSG","9122"]],
+      AXIS["Latitude",NORTH],
+      AXIS["Longitude",EAST],
+      AUTHORITY["EPSG","4326"]]
+  Splitting long ways
+  Writing file header
+  Writing nodes
+  Writing ways
+  Writing relations
+  Writing file footer
+  $ xmllint --format unnecessary_collection.osm | diff -uNr - $TESTDIR/unnecessary_collection.xml
+
 mergetags:
   $ ogr2osm -f $TESTDIR/shapefiles/mergetags.geojson
   Using default translations

--- a/test/shapefiles/unnecessary_collection.geojson
+++ b/test/shapefiles/unnecessary_collection.geojson
@@ -1,0 +1,36 @@
+{
+  "type" : "FeatureCollection",
+  "features" : [{
+    "type" : "Feature",
+    "geometry" : {
+      "type" : "GeometryCollection",
+      "geometries" : [
+        {
+          "type" : "Polygon",
+          "coordinates" : [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                1,
+                1
+              ],
+              [
+                0,
+                1
+              ],
+              [
+                0,
+                0
+            ]
+          ]
+        ]}
+      ]
+    },
+    "properties" : {
+      "name": "yes"
+    }
+  }]
+}

--- a/test/unnecessary_collection.xml
+++ b/test/unnecessary_collection.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="ogr2osm 1.2.0" upload="false">
+  <node visible="true" id="-1" lat="0" lon="0"/>
+  <node visible="true" id="-2" lat="1" lon="1"/>
+  <node visible="true" id="-3" lat="1" lon="0"/>
+  <way visible="true" id="-4">
+    <nd ref="-1"/>
+    <nd ref="-2"/>
+    <nd ref="-3"/>
+    <nd ref="-1"/>
+    <tag k="name" v="yes"/>
+  </way>
+</osm>


### PR DESCRIPTION
If an unnecessary Polygon FeatureCollection was provided (i.e. a Collection with a single Polygon) the code broke with the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/ogr2osm", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/ogr2osm/ogr2osm.py", line 271, in main
    osmdata.process(datasource)
  File "/usr/local/lib/python3.10/dist-packages/ogr2osm/osm_data.py", line 422, in process
    self.add_feature(ogrfeature, layer_fields, datasource.source_encoding, reproject)
  File "/usr/local/lib/python3.10/dist-packages/ogr2osm/osm_data.py", line 370, in add_feature
    osmgeometries = self.__parse_geometry(ogrgeometry, feature_tags)
  File "/usr/local/lib/python3.10/dist-packages/ogr2osm/osm_data.py", line 345, in __parse_geometry
    osmgeometries.append(self.__parse_collection(ogrgeometry, tags))
  File "/usr/local/lib/python3.10/dist-packages/ogr2osm/osm_data.py", line 313, in __parse_collection
    if len(members) == 1 and len(members[0].nodes) <= self.max_points_in_way:
```

Fixing the tuple reference in https://github.com/roelderickx/ogr2osm/blob/2a0c8b22311aea1dfc63577f986febc493321b61/ogr2osm/osm_data.py#L318-L320 would fix the error but the tags would get distorted, as a list-value is expected but a simple string-value is given to the tags dict in https://github.com/roelderickx/ogr2osm/blob/2a0c8b22311aea1dfc63577f986febc493321b61/ogr2osm/osm_data.py#L320.

I therefore chose to handle unnecessary Collections earlier pretending they are just normal geometries.

*Context*

This has nothing to do with the MR directly but I stumbled up on the issue while exporting some data from ohsome.org and then trying to convert the geojson back to the OSM data format just as I had done here: https://heigit.org/2022-30daymapchallenge-round-up-part-2-deleted-maps/ . The offender was identified as this relation https://www.openstreetmap.org/relation/3088804 (a relation with a child relation). Ohsome chooses to ignore the child relation and provide an unnecessary Collection: 

```
curl -X POST "https://api.ohsome.org/v1/elements/geometry"  \
  -d "bboxes=8.67,49.39,8.71,49.42"  \
  -d "clipGeometry=true"  \
  -d "filter=id:relation/3088804"   \
  -d "properties=tags,metadata"   \
  -d "time=2024-10-01T12:00Z"   \
  -H "accept: application/json"   \
  -o data/test.geojson
```